### PR TITLE
Message provenance

### DIFF
--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/BufferedItem.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/BufferedItem.java
@@ -39,6 +39,7 @@
  ******************************************************************************/
 package gov.pnnl.proven.cluster.lib.disclosure.exchange;
 
+
 /**
  * Represents a data item that is queued for processing as it enters the Proven
  * platform. These items may be queued/processed multiple times depending on the
@@ -57,3 +58,5 @@ public interface BufferedItem {
 	void setItemState(BufferedItemState buffereState);
 
 }
+
+

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureProperty.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureProperty.java
@@ -71,9 +71,7 @@ public enum DisclosureProperty {
 	IS_STATIC("isStatic", JsonValue.FALSE),
 	IS_TRANSIENT("isTransient", JsonValue.FALSE),
 	MESSAGE("message", JsonValue.NULL),
-	MESSAGE_SCHEMA("messageSchema", JsonValue.NULL),
-	MESSAGE_ID("messageId", Json.createValue(UUID.randomUUID().toString())),
-	SOURCE_MESSAGE_ID("sourceMessageId", JsonValue.NULL);
+	MESSAGE_SCHEMA("messageSchema", JsonValue.NULL);
 
 	static Logger log = LoggerFactory.getLogger(DisclosureProperty.class);
 

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureProperty.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureProperty.java
@@ -37,90 +37,63 @@
  * PACIFIC NORTHWEST NATIONAL LABORATORY operated by BATTELLE for the 
  * UNITED STATES DEPARTMENT OF ENERGY under Contract DE-AC05-76RL01830
  ******************************************************************************/
-package gov.pnnl.proven.cluster.lib.disclosure.message;
+package gov.pnnl.proven.cluster.lib.disclosure.exchange;
 
-import java.io.IOException;
-import java.io.Serializable;
+import java.util.UUID;
+
+import javax.json.Json;
+import javax.json.JsonValue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-
-import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
+import gov.pnnl.proven.cluster.lib.disclosure.DomainProvider;
 
 /**
- * Disclosure messages represent the original input message disclosed to the
- * platform. It is responsible for transforming its message content into either
- * a {@code KnowledgeMessage} or {@code RequestMessage} for downstream message
- * processing.
+ * Represents first level key names for a disclosed JSON Proven message. Default
+ * property values, if any, are identified.
+ * 
+ * Note: This must align with the Proven message schema.
  * 
  * @author d3j766
  *
  */
-public class DisclosureMessage extends ProvenMessage implements IdentifiedDataSerializable, Serializable {
+public enum DisclosureProperty {
 
-	private static final long serialVersionUID = 1L;
-	private static Logger log = LoggerFactory.getLogger(DisclosureMessage.class);
+	AUTH_TOKEN("authToken", JsonValue.NULL),
+	DOMAIN("domain", Json.createValue(DomainProvider.PROVEN_DISCLOSURE_DOMAIN)),
+	NAME("name", JsonValue.NULL),
+	CONTENT("content", JsonValue.NULL),
+	QUERY_TYPE("queryType", JsonValue.NULL),
+	QUERY_LANGUAGE("queryLanguage", JsonValue.NULL),
+	DISCLOSURE_ID("disclosureId", JsonValue.NULL),
+	REQUESTOR_ID("requestorId", JsonValue.NULL),
+	IS_STATIC("isStatic", JsonValue.FALSE),
+	IS_TRANSIENT("isTransient", JsonValue.FALSE),
+	MESSAGE("message", JsonValue.NULL),
+	MESSAGE_SCHEMA("messageSchema", JsonValue.NULL),
+	MESSAGE_ID("messageId", Json.createValue(UUID.randomUUID().toString())),
+	SOURCE_MESSAGE_ID("sourceMessageId", JsonValue.NULL);
 
-	/**
-	 * True, if the disclosed content is in the Request message group.
-	 */
-	boolean isRequest;
+	static Logger log = LoggerFactory.getLogger(DisclosureProperty.class);
 
-	/**
-	 * True, if the disclosed content is in the Knowledge message group.
-	 */
-	boolean isKnowledge;
+	private String property;
+	private JsonValue defaultValue;
 
-	/**
-	 * True, if the disclosed content is a {@code MessageContent#Measurement}.
-	 */
-	boolean hasMeasurements;
-
-	public DisclosureMessage() {
+	DisclosureProperty(String property, JsonValue defaultValue) {
+		this.property = property;
+		this.defaultValue = defaultValue;
 	}
 
-	public DisclosureMessage(DisclosureItem di) {
-		super(di);
-		MessageContent disclosedContent = di.getContent();
-		MessageContentGroup disclosedContentGroup = MessageContentGroup.getType(di.getContent());
-		isRequest = MessageContentGroup.Request == disclosedContentGroup;
-		isKnowledge = MessageContentGroup.Knowledge == disclosedContentGroup;
-		hasMeasurements = MessageContent.Measurement == disclosedContent;
+	public String getProperty() {
+		return property;
 	}
 
-	@Override
-	public MessageContent getMessageContent() {
-		return MessageContent.Disclosure;
+	public boolean hasDefault() {
+		return getDefaultValue() != JsonValue.NULL;
 	}
 
-	@Override
-	public void readData(ObjectDataInput in) throws IOException {
-		super.readData(in);
-		this.isRequest = in.readBoolean();
-		this.isKnowledge = in.readBoolean();
-		this.hasMeasurements = in.readBoolean();
+	public JsonValue getDefaultValue() {
+		return defaultValue;
 	}
-
-	@Override
-	public void writeData(ObjectDataOutput out) throws IOException {
-		super.writeData(out);
-		out.writeBoolean(this.isRequest);
-		out.writeBoolean(this.isKnowledge);
-		out.writeBoolean(this.hasMeasurements);
-	}
-
-	@Override
-	public int getFactoryId() {
-		return ProvenMessageIDSFactory.FACTORY_ID;
-	}
-
-	@Override
-	public int getId() {
-		return ProvenMessageIDSFactory.DISCLOSURE_MESSAGE_TYPE;
-	}
-
 }

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureType.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/exchange/DisclosureType.java
@@ -45,12 +45,8 @@ import javax.json.stream.JsonParsingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonParseException;
-
-import gov.pnnl.proven.cluster.lib.disclosure.exception.JSONDataValidationException;
 import gov.pnnl.proven.cluster.lib.disclosure.exception.UnsupportedDisclosureType;
 import gov.pnnl.proven.cluster.lib.disclosure.message.CsvDisclosure;
-import gov.pnnl.proven.cluster.lib.disclosure.message.DisclosureMessage;
 import gov.pnnl.proven.cluster.lib.disclosure.message.JsonDisclosure;
 import gov.pnnl.proven.cluster.lib.disclosure.message.exception.CsvParsingException;
 
@@ -59,7 +55,7 @@ import gov.pnnl.proven.cluster.lib.disclosure.message.exception.CsvParsingExcept
  * Each type, currently CSV or JSON, have pre-defined regular expression used to
  * determine the item's type.
  * 
- * Internal disclosure is always JSON.
+ * Internal message representation is JSON.
  * 
  * @author d3j766
  *
@@ -95,7 +91,7 @@ public enum DisclosureType {
 	}
 
 	/**
-	 * Determines an external disclosure entrie's type.
+	 * Determines type of disclosure item.
 	 * 
 	 * @param item
 	 *            the disclosure item
@@ -106,8 +102,8 @@ public enum DisclosureType {
 	 * @throws CsvParsingException
 	 *             if parsing failed for a CSV type
 	 * 
-	 * @return the {@code DisclosureType}. Returns null if type could not
-	 *         be determined.
+	 * @return the {@code DisclosureType}. Returns null if type could not be
+	 *         determined.
 	 */
 	public static DisclosureType getItemType(String item) throws UnsupportedDisclosureType {
 
@@ -125,41 +121,19 @@ public enum DisclosureType {
 	}
 
 	/**
-	 * Creates and returns a {@code DisclosureMessage} for an external
-	 * disclosure entry.
+	 * Creates and returns a JSON object for the provided data item.
 	 * 
 	 * @param item
-	 *            the disclosure item
+	 *            a data item matching a supported DisclosureType
+	 * @return the JsonObject
 	 * @throws UnsupportedDisclosureType
-	 *             if the type could not be determined.
+	 *             if item type is not supported
 	 * @throws JsonParsingException
-	 *             if parsing failed for a JSON item
+	 *             if not a valid JSON string
 	 * @throws CsvParsingException
-	 *             if parsing failed for a CSV item
-	 * 
-	 * @return the {@code DisclosureType}
+	 *             if not a valid CSV string
 	 */
-	public static DisclosureMessage getDisclosureMessage(String item) throws UnsupportedDisclosureType,
-			JsonParsingException, CsvParsingException, JSONDataValidationException, Exception {
-
-		DisclosureMessage ret = null;
-
-		if (item.matches(CSV.getRegex())) {
-			ret = new DisclosureMessage(CsvDisclosure.toJsonObject(item));
-		}
-
-		if (item.matches(JSON.getRegex())) {
-			ret = new DisclosureMessage(JsonDisclosure.toJsonObject(item));
-		}
-
-		if (null == ret) {
-			throw new UnsupportedDisclosureType();
-		}
-
-		return ret;
-	}
-
-	public static JsonObject getJsonEntry(String item) throws UnsupportedDisclosureType {
+	public static JsonObject getJsonItem(String item) throws UnsupportedDisclosureType {
 
 		JsonObject ret = null;
 

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/KnowledgeMessage.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/KnowledgeMessage.java
@@ -41,16 +41,19 @@ package gov.pnnl.proven.cluster.lib.disclosure.message;
 
 import java.io.IOException;
 import java.io.Serializable;
-import javax.json.JsonObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 /**
- * Represents a knowledge message.  Content type is determined at disclosure.    
- *  
+ * Represents a knowledge message. Provides semantic information for processing
+ * and storage in the hybrid store. Knowledge content is comprised of several
+ * MessageContent types.
+ * 
  * @author d3j766
  *
  * @see MessageContent
@@ -59,35 +62,24 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 public class KnowledgeMessage extends ProvenMessage implements IdentifiedDataSerializable, Serializable {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	private static Logger log = LoggerFactory.getLogger(KnowledgeMessage.class);
-	
-	MessageContent contentType;
-	
-	
+
 	public KnowledgeMessage() {
 	}
 
-	public KnowledgeMessage(JsonObject message, MessageContent contentType) {
-		super(message);
-		this.contentType = contentType;
-	}
-		
-	@Override
-	public MessageContent getMessageContent() {
-		return contentType;
+	public KnowledgeMessage(ProvenMessage source) {
+		super(source);
 	}
 
 	@Override
 	public void readData(ObjectDataInput in) throws IOException {
 		super.readData(in);
-		this.contentType = MessageContent.valueOf(in.readUTF());
 	}
 
 	@Override
 	public void writeData(ObjectDataOutput out) throws IOException {
 		super.writeData(out);
-		out.writeUTF(this.contentType.toString());
 	}
 
 	@Override
@@ -98,6 +90,6 @@ public class KnowledgeMessage extends ProvenMessage implements IdentifiedDataSer
 	@Override
 	public int getId() {
 		return ProvenMessageIDSFactory.KNOWLEDGE_MESSAGE_TYPE;
-	}	
-	
+	}
+
 }

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/MessageContent.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/MessageContent.java
@@ -104,9 +104,9 @@ public enum MessageContent {
 	/**
 	 * Continuous Query message content. Queries to run over a cluster member's
 	 * ProvenMessage data name for a configured frequency, in order to detect
-	 * and/or create new purposed message content. This is a type of
+	 * and/or create newly purposed message content. This is a type of
 	 * {@link MessageContent#Query}; query results are not returned to
-	 * requester, but instead is installed on server for processing.
+	 * requester, but instead are saved in platform for future processing.
 	 */
 	ContinuousQuery(MessageContentName.CONTINUOUS_QUERY),
 

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/ProvenMessageIDSFactory.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/ProvenMessageIDSFactory.java
@@ -32,11 +32,11 @@ public class ProvenMessageIDSFactory implements DataSerializableFactory {
 	public static final int PROVEN_STATEMENT_TYPE = 7;
 	public static final int DISCLOSURE_MESSAGE_TYPE = 8;
 	public static final int KNOWLEDGE_MESSAGE_TYPE = 9;
-	public static final int REQUEST_MESSAGE_TYPE = 10;	
-	public static final int DISCLOSURE_PROXY_TYPE = 11;
+	public static final int REQUEST_MESSAGE_TYPE = 10;
 	public static final int RESPONSE_MESSAGE_TYPE = 12;
 	public static final int DISCLOSURE_DOMAIN_TYPE = 13;
-	
+	public static final int DISCLOSURE_ITEM_TYPE = 14;
+
 	@Override
 	public IdentifiedDataSerializable create(int typeId) {
 
@@ -58,17 +58,17 @@ public class ProvenMessageIDSFactory implements DataSerializableFactory {
 		case (PROVEN_STATEMENT_TYPE):
 			return new ProvenStatement();
 		case (DISCLOSURE_MESSAGE_TYPE):
-			return new DisclosureMessage();		
+			return new DisclosureMessage();
 		case (KNOWLEDGE_MESSAGE_TYPE):
 			return new KnowledgeMessage();
 		case (REQUEST_MESSAGE_TYPE):
-			return new RequestMessage();		
-		case (DISCLOSURE_PROXY_TYPE):
-			return new DisclosureItem();
+			return new RequestMessage();
 		case (RESPONSE_MESSAGE_TYPE):
 			return new ResponseMessage();
 		case (DISCLOSURE_DOMAIN_TYPE):
-			return new DisclosureDomain();		
+			return new DisclosureDomain();
+		case (DISCLOSURE_ITEM_TYPE):
+			return new DisclosureItem();
 		default:
 			return null;
 		}

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/RequestMessage.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/RequestMessage.java
@@ -41,9 +41,6 @@ package gov.pnnl.proven.cluster.lib.disclosure.message;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.UUID;
-
-import javax.json.JsonObject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,10 +49,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-
 /**
- * Represents a request message.  Content type is determined at disclosure.    
- *  
+ * Represents a request message. Provides information describing a request being
+ * made of the Proven platform. Request content is comprised of several
+ * MessageContent type.
+ * 
  * @author d3j766
  *
  * @see MessageContent
@@ -64,35 +62,24 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 public class RequestMessage extends ProvenMessage implements IdentifiedDataSerializable, Serializable {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	private static Logger log = LoggerFactory.getLogger(RequestMessage.class);
-	
-	MessageContent contentType;
-	
-	
+
 	public RequestMessage() {
 	}
 
-	public RequestMessage(JsonObject message, MessageContent contentType) {
-		super(message);
-		this.contentType = contentType;
-	}
-		
-	@Override
-	public MessageContent getMessageContent() {
-		return contentType;
+	public RequestMessage(ProvenMessage source) {
+		super(source);
 	}
 
 	@Override
 	public void readData(ObjectDataInput in) throws IOException {
 		super.readData(in);
-		this.contentType = MessageContent.valueOf(in.readUTF());
 	}
 
 	@Override
 	public void writeData(ObjectDataOutput out) throws IOException {
 		super.writeData(out);
-		out.writeUTF(this.contentType.toString());
 	}
 
 	@Override
@@ -103,6 +90,6 @@ public class RequestMessage extends ProvenMessage implements IdentifiedDataSeria
 	@Override
 	public int getId() {
 		return ProvenMessageIDSFactory.REQUEST_MESSAGE_TYPE;
-	}	
-	
+	}
+
 }

--- a/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/ResponseMessage.java
+++ b/proven-member/disclosure-lib/src/main/java/gov/pnnl/proven/cluster/lib/disclosure/message/ResponseMessage.java
@@ -40,20 +40,23 @@
 package gov.pnnl.proven.cluster.lib.disclosure.message;
 
 import java.io.IOException;
+
 import javax.json.JsonObject;
 import javax.ws.rs.core.Response;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
-import gov.pnnl.proven.cluster.lib.disclosure.DisclosureDomain;
+import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
 
 /**
- * General response message. A response message is created or based on a
- * disclosed {@code ProvenMessage}. The response may be for the disclosure
- * itself or for the execution of a requested service defined in the message.
+ * Messages created in response to events (e.g. disclosure, request processing,
+ * knowledge processing, etc.) occurring within the Proven platform. They
+ * provide a record of the event's status and other related data. These messages
+ * are published as Server-Sent Events (SSE) making them available for client
+ * consumption.
  * 
- * @see ProvenMessage, DisclosureMessage, KnowledgeMessage, RequestMessage
+ * @see ProvenMessage
  * 
  * @author d3j766
  *
@@ -61,6 +64,11 @@ import gov.pnnl.proven.cluster.lib.disclosure.DisclosureDomain;
 public class ResponseMessage extends ProvenMessage {
 
 	private static final long serialVersionUID = 1L;
+
+	/**
+	 * JSON response message
+	 */
+	protected JsonObject responseMessage;
 
 	/**
 	 * Response status using commonly used HTTP status codes
@@ -76,17 +84,28 @@ public class ResponseMessage extends ProvenMessage {
 
 	public ResponseMessage() {
 	}
-
-	public ResponseMessage(Response.Status status, ProvenMessage sourceMessage, JsonObject message) {
-		this(status, sourceMessage, message, null);
+	
+	public ResponseMessage(Response.Status status, JsonObject responseMessage, DisclosureItem di) {
+		super(di);
+		this.responseMessage = responseMessage;
+		this.status = status;
+		this.sourceContentType = di.getContent();
 	}
-
-	public ResponseMessage(Response.Status status, ProvenMessage sourceMessage, JsonObject message, JsonObject schema) {
-		super(sourceMessage, message, schema);
+	
+	public ResponseMessage(Response.Status status, JsonObject response, ProvenMessage sourceMessage) {
+		super(sourceMessage);
+		this.responseMessage = response;
 		this.status = status;
 		this.sourceContentType = sourceMessage.getMessageContent();
 	}
-	
+
+	public JsonObject getResponseMessage() {
+		return responseMessage;
+	}
+
+	public void setResponseMessage(JsonObject responseMessage) {
+		this.responseMessage = responseMessage;
+	}
 
 	public Response.Status getStatus() {
 		return status;

--- a/proven-member/disclosure-lib/src/main/resources/message-model/proven-schema.json
+++ b/proven-member/disclosure-lib/src/main/resources/message-model/proven-schema.json
@@ -1,5 +1,7 @@
 {
-	"definitions": {},
+	"definitions": {
+		
+	},
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "http://proven.pnnl.gov/proven-schema.json",
 	"type": "object",
@@ -8,27 +10,30 @@
 		"authToken": {
 			"$id": "#/properties/authToken",
 			"type": "string",
-			"title": "The Authtoken Schema",
+			"title": "Authorization Token",
+			"description": "A JSON Web token used to describe authorization claims/capabilities for an authenticated user.  See https://tools.ietf.org/html/rfc7519 and Proven documentation.",
 			"default": "",
 			"examples": [
-				"token-value"
+				""
 			],
-			"pattern": "^(.*)$"
+			"pattern": "^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$"
 		},
 		"domain": {
 			"$id": "#/properties/domain",
 			"type": "string",
-			"title": "The Domain Schema",
-			"default": "",
+			"title": "Fully qualified domain name",
+			"description": "Defines a data space for data/information discolsed to the Proven platform.",
+			"default": "common.proven.pnnl.gov",
 			"examples": [
 				"gridappsd.pnnl.gov"
 			],
-			"pattern": "^(.*)$"
+			"pattern": "^([a-z0-9]+(-[a-z0-9]+)*\\.)+[a-z]{2,}$"
 		},
 		"name": {
 			"$id": "#/properties/name",
 			"type": "string",
-			"title": "The Name Schema",
+			"title": "Message name",
+			"description": "User provided name for a disclosed message.",
 			"default": "",
 			"examples": [
 				"SimulationOutput"
@@ -38,92 +43,84 @@
 		"content": {
 			"$id": "#/properties/content",
 			"type": "string",
-			"enum": ["explicit", "implicit", "measurement", "static","structure", "administrative", "continuousquery", "PipelineRequest", "ModuleRequest", "query"],
-			"title": "The Content Schema",
+			"enum": [
+				"explicit",
+				"implicit",
+				"measurement",
+				"static",
+				"structure",
+				"administrative",
+				"continuous",
+				"pipeline",
+				"module",
+				"query"
+			],
+			"title": "Type of message content",
+			"description": "Message content type determines how message will be processed by the Proven platform.  See Proven documentation for a description of each content type.",
 			"default": "",
 			"examples": [
-				"Explicit"
+				""
 			],
 			"pattern": "^(.*)$"
 		},
 		"disclosureId": {
 			"$id": "#/properties/disclosureId",
 			"type": "string",
-			"title": "The Disclosureid Schema",
+			"title": "Disclosure identifier",
+			"description": "User provided information identifying messages disclosed by a user.  This can be used to filter responses from the Proven platform.",
 			"default": "",
 			"examples": [
-				"abc12434"
+				"Simulation_A"
 			],
 			"pattern": "^(.*)$"
 		},
 		"requestorId": {
 			"$id": "#/properties/requestorId",
 			"type": "string",
-			"title": "The Requestorid Schema",
+			"title": "Requestor identifier",
+			"description": "User provided information identifying requestor (i.e. origin or source) of disclosed messages.  This can be used to filter responses from the Proven platform.",
 			"default": "",
 			"examples": [
-				"xyz356436"
+				"Grid_A messages"
 			],
 			"pattern": "^(.*)$"
 		},
 		"isStatic": {
 			"$id": "#/properties/isStatic",
 			"type": "boolean",
-			"title": "The Isstatic Schema",
+			"title": "Static message data",
+			"description": "Message content will be treated as static.  Meaning, data will not be aged off of the memory component of the hybrid store.",
 			"default": false,
 			"examples": [
-				true, false
+				true,
+				false
 			]
 		},
 		"isTransient": {
 			"$id": "#/properties/isTransient",
 			"type": "boolean",
-			"title": "The Istransient Schema",
+			"title": "Transient message data",
+			"description": "Indicates message content is transient, meaning the message will not be persisted to a registered semantic or time series store.  The content will be stored in the memory store, and will be discarded when it ages off.",
 			"default": false,
 			"examples": [
-				true, false
+				true,
+				false
 			]
 		},
-
 		"message": {
 			"$id": "#/properties/message",
 			"type": "object",
-			"title": "The Message Schema"
-
+			"title": "Message",
+			"description": "Contains the message, that is, a JSON object containing the message content. "
 		},
-		"message-schema": {
-			"$id": "#/properties/message-schema",
+		"messageSchema": {
+			"$id": "#/properties/messageSchema",
 			"type": "object",
-			"title": "The Message-schema Schema",
-			"default": null
+			"title": "Message schema",
+			"description": "A JSON object containing the message's JSON schema.  A domain discloser can provide to support server side message validation."
 		}
 	},
-	"allOf": [{
-			"if": {
-				"properties": {
-					"content": {
-						"const": "explicit"
-					}
-				}
-			},
-			"then": {
-				"properties": {
-					"mimeType": {
-						"$id": "#/properties/mimeType",
-						"type": "string",
-						"title": "The Mimetype Schema",
-						"default": "",
-						"examples": [
-							"application/json"
-						],
-						"pattern": "^(.*)$"
-					}
-				},
-				"required": [
-					"mimeType"
-				]
-			}
-		},
+	"allOf": [
 		{
 			"if": {
 				"properties": {
@@ -137,22 +134,34 @@
 					"queryType": {
 						"$id": "#/properties/queryType",
 						"type": "string",
-						"enum": ["hybrid", "stream", "timeseries", "semantic"],
-					    "title": "The queryType Schema",
+						"enum": [
+							"hybrid",
+							"stream",
+							"timeseries",
+							"semantic"
+						],
+						"title": "Query type",
+						"description": "Identifies the type of query.  See Proven documentation for a description of the supported query types.",
 						"default": "",
 						"examples": [
-							"timeseries"
+							""
 						],
 						"pattern": "^(.*)$"
 					},
 					"queryLanguage": {
 						"$id": "#/properties/queryLanguage",
 						"type": "string",
-						"enum": ["sparql", "influxql", "PredicateBuilder", "StreamQuery"],
-						"title": "The queryLanguage Schema",
+						"enum": [
+							"sparql",
+							"influxql",
+							"PredicateBuilder",
+							"StreamQuery"
+						],
+						"title": "Query language",
+						"description": "Identifies the query language.  See Proven documentation for a description of the supported query languages.",
 						"default": "",
 						"examples": [
-							"influxql"
+							""
 						],
 						"pattern": "^(.*)$"
 					}

--- a/proven-member/disclosure-lib/src/main/resources/message-model/schema-test.json
+++ b/proven-member/disclosure-lib/src/main/resources/message-model/schema-test.json
@@ -1,0 +1,12 @@
+{
+	"authToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjJ9.tbDepxpstvGdW8TC3G8zg4B6rUYAOvfzdceoH48wgRQ",
+	"domain": "common.proven.pnnl.gov",
+	"name": "SimulationOutput",
+	"content": "explicit",
+	"disclosureId": "abc244",
+	"requestorId": "xyx456",
+	"isStatic": true,
+	"isTransient": true,
+	"message": {"test": "message"},
+	"message-schema": {}
+}

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/dto/SseRegisterEventDto.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/dto/SseRegisterEventDto.java
@@ -82,7 +82,7 @@ public class SseRegisterEventDto implements SseEventData, Serializable {
 		for (MessageContent mc : session.getContents()) {
 			this.registeredMessageContents.add(mc.getName());
 		}
-		this.registeredRequester = session.getRequester();
+		this.registeredRequester = session.getRequestor();
 	}
 
 	public String getSessionId() {

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/dto/SseResponseEventDto.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/dto/SseResponseEventDto.java
@@ -40,6 +40,8 @@
 package gov.pnnl.proven.cluster.module.disclosure.dto;
 
 import java.io.Serializable;
+import java.util.Optional;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +71,7 @@ public class SseResponseEventDto implements SseEventData, Serializable {
 
 	String messageContent;
 
-	String requester;
+	String requestorId;
 
 	String disclosureId;
 
@@ -86,14 +88,16 @@ public class SseResponseEventDto implements SseEventData, Serializable {
 
 	public SseResponseEventDto(SseSession session, ResponseMessage message) {
 		this.sessionId = session.getSessionId().toString();
-		this.domain = message.getDomain().getDomain();
+		this.domain = message.getDisclosureItem().getDisclosureDomain().getDomain();
 		this.messageContent = message.getMessageContent().getName();
-		this.requester = message.getRequester();
-		this.disclosureId = message.getDisclosureId();
+		Optional<String> requestorIdOpt = message.getDisclosureItem().getRequestorId();
+		this.requestorId = (requestorIdOpt.isPresent()) ? requestorIdOpt.get() : "NONE";       
+		Optional<String> disclosureIdOpt = message.getDisclosureItem().getDisclosureId();
+		this.disclosureId = (disclosureIdOpt.isPresent()) ? disclosureIdOpt.get() : "NONE";
 		this.status = message.getStatus().getStatusCode();
 		this.reason = message.getStatus().getReasonPhrase();
 		this.key = message.getMessageKey();
-		this.message = message.getMessage().toString();
+		this.message = message.getResponseMessage().toString();
 	}
 
 	public String getSessionId() {
@@ -121,11 +125,11 @@ public class SseResponseEventDto implements SseEventData, Serializable {
 	}
 
 	public String getRequester() {
-		return requester;
+		return requestorId;
 	}
 
 	public void setRequester(String requester) {
-		this.requester = requester;
+		this.requestorId = requester;
 	}
 
 	public String getDisclosureId() {

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/resource/SseSessionResource.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/resource/SseSessionResource.java
@@ -152,7 +152,7 @@ public class SseSessionResource {
 	 *            value will be sent. If not provided all contentTypes are
 	 *            included.
 	 * @param requestor
-	 *            (optional) identifies disclosure source (i.e. requester) that
+	 *            (optional) identifies disclosure source (i.e. requestor) that
 	 *            the response event is based on. This must be provided at
 	 *            disclosure time for a match to be made. Only events matching
 	 *            this value will be sent. If not provided all disclosure

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/resource/TestSSEResponse.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/resource/TestSSEResponse.java
@@ -52,9 +52,11 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.slf4j.Logger;
 import static gov.pnnl.proven.cluster.module.disclosure.resource.DisclosureResourceConsts.RR_SSE;
 import gov.pnnl.proven.cluster.lib.disclosure.DomainProvider;
+import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
 import gov.pnnl.proven.cluster.lib.disclosure.message.DisclosureMessage;
 import gov.pnnl.proven.cluster.lib.disclosure.message.JsonDisclosure;
 import gov.pnnl.proven.cluster.lib.disclosure.message.MessageContentGroup;
+import gov.pnnl.proven.cluster.lib.disclosure.message.MessageModel;
 import gov.pnnl.proven.cluster.lib.disclosure.message.ResponseMessage;
 import gov.pnnl.proven.cluster.lib.module.stream.MessageStreamProxy;
 import gov.pnnl.proven.cluster.lib.module.stream.MessageStreamType;
@@ -65,6 +67,8 @@ public class TestSSEResponse {
 
 	@Inject
 	Logger logger;
+	
+	private final static String SCHEMA_TEST_FILE = "schema-test.json";
 
 	@StreamConfig(domain = DomainProvider.PROVEN_DISCLOSURE_DOMAIN, streamType = MessageStreamType.Response)
 	@Inject
@@ -77,6 +81,8 @@ public class TestSSEResponse {
 		Response ret = Response.ok().build();
 
 		logger.debug("START :: " + Calendar.getInstance().getTime().toString());
+		
+		MessageModel mm = MessageModel.getInstance(DomainProvider.getProvenDisclosureDomain());
 
 		int i = 0;
 		int iterations = count;
@@ -87,12 +93,12 @@ public class TestSSEResponse {
 					.add("count", String.valueOf(i)).build();
 			logger.debug("Test Message :: " + testMessage.toString());
 
-			// Create source message
-			DisclosureMessage jd = new DisclosureMessage(JsonDisclosure.toJsonObject(testMessage.toString()));
+			// Create source message - just needed to be able to create test response message
+			DisclosureMessage dm = new DisclosureMessage(new DisclosureItem(mm.getModelFile(SCHEMA_TEST_FILE)));
 
 			// Create new response message and add - this should cause a send
 			// event on server
-			ResponseMessage rm = new ResponseMessage(Status.OK, jd, jd.getMessage());
+			ResponseMessage rm = new ResponseMessage(Status.OK, dm.getDisclosureItem().getMessage(), dm);
 
 			// Add message to queue
 			msp.getMessageStream().getStream().put(rm.getMessageKey(), rm);

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/sse/SseSession.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/sse/SseSession.java
@@ -78,7 +78,7 @@ public class SseSession {
 	private SseEventSink eventSink;
 	private DisclosureDomain domain;
 	private List<MessageContent> contents;
-	private String requester;
+	private String requestor;
 
 	public SseSession(SseEvent event, UUID sessionId, Sse sse, SseEventSink eventSink, Optional<String> domainOpt,
 			Optional<List<String>> contentsOpt, Optional<String> requesterOpt) {
@@ -92,8 +92,8 @@ public class SseSession {
 		this.domain = DomainProvider.getProvenDisclosureDomain();
 		if ((domainOpt.isPresent()) && (DisclosureDomain.isValidDomain(domainOpt.get()))) {
 			this.domain = new DisclosureDomain(domainOpt.get());
-		}
 
+		}
 		// contents
 		this.contents = new ArrayList<MessageContent>();
 		this.contents.add(Any);
@@ -122,15 +122,15 @@ public class SseSession {
 		}
 
 		// requester
-		this.requester = null;
+		this.requestor = null;
 		if ((requesterOpt.isPresent()) && (!requesterOpt.get().isEmpty())) {
-			this.requester = requesterOpt.get();
+			this.requestor = requesterOpt.get();
 		}
 
 		logger.debug("Created new SSE Session:");
 		logger.debug("\tDomain: " + this.domain.getDomain());
 		logger.debug("\tMessageContent: " + this.contents.toString());
-		logger.debug("\tRequester: " + ((null == this.requester) ? ("Any") : (this.requester)));
+		logger.debug("\tRequester: " + ((null == this.requestor) ? ("Any") : (this.requestor)));
 		logger.debug("");
 
 	}
@@ -156,13 +156,12 @@ public class SseSession {
 		return ret;
 	}
 
-	public boolean hasRequester(String requesterToCheck) {
+	public boolean hasRequestor(Optional<String> requesterToCheck) {
 
 		boolean ret = true;
-		if (null != requester) {
-			ret = requester.equals(requesterToCheck);
+		if ((requesterToCheck.isPresent()) && (!requesterToCheck.get().isEmpty())) {
+			ret = requestor.equals(requesterToCheck.get());
 		}
-
 		return ret;
 	}
 
@@ -244,12 +243,12 @@ public class SseSession {
 		this.contents = contents;
 	}
 
-	public String getRequester() {
-		return requester;
+	public String getRequestor() {
+		return requestor;
 	}
 
 	public void setRequester(String requester) {
-		this.requester = requester;
+		this.requestor = requester;
 	}
 
 }

--- a/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/sse/SseSessionManager.java
+++ b/proven-member/disclosure-module/src/main/java/gov/pnnl/proven/cluster/module/disclosure/sse/SseSessionManager.java
@@ -43,6 +43,8 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -429,7 +431,7 @@ public class SseSessionManager implements EntryAddedListener<String, ProvenMessa
 			try {
 				MessageContent mc = message.getMessageContent();
 				MessageStreamType mst = MessageStreamType.getType(mc);
-				DisclosureDomain dd = message.getDomain();
+				DisclosureDomain dd = message.getDisclosureItem().getDisclosureDomain();
 				SimpleEntry<DisclosureDomain, MessageStreamType> se = new SimpleEntry<>(dd, mst);
 				Set<SseSession> sessions = sessionRegistry.get(se);
 				boolean hasSessions = ((null != sessions) && (!sessions.isEmpty()));
@@ -440,8 +442,8 @@ public class SseSessionManager implements EntryAddedListener<String, ProvenMessa
 
 						// Check if event data should be sent to session
 						boolean hasDomain = session.hasDomain(dd);
-						boolean hasContent = session.hasContent(mc);
-						boolean hasRequester = session.hasRequester(message.getRequester());
+						boolean hasContent = session.hasContent(mc);						
+						boolean hasRequester = session.hasRequestor(message.getDisclosureItem().getRequestorId());
 						boolean sendEvent = ((hasDomain) && (hasContent) && (hasRequester));
 
 						if (sendEvent) {

--- a/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/DisclosureBuffer.java
+++ b/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/DisclosureBuffer.java
@@ -147,11 +147,11 @@ public class DisclosureBuffer extends ExchangeBuffer<DisclosureItem> {
 
 				items.forEach((item) -> {
 					try {
-						DisclosureMessage dm = item.getDisclosureMessage();
-						MessageStreamProxy msp = sm.getMessageStreamProxy(dm.getDomain(), mst);
+						DisclosureMessage dm = new DisclosureMessage(item);
+						MessageStreamProxy msp = sm.getMessageStreamProxy(dm.getDisclosureItem().getDisclosureDomain(), mst);
 						msp.addMessage(dm);
 						log.debug("Added Disclosure messsage to stream :: " + dm.getMessageKey());
-					} catch (UnsupportedMessageContentException | UnsupportedDisclosureType | JsonParsingException
+					} catch (UnsupportedMessageContentException | JsonParsingException
 							| InvalidDisclosureDomainException | CsvParsingException e) {
 						log.error("Failed to create and add new disclosure message to stream", e);
 

--- a/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/DisclosureQueue.java
+++ b/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/DisclosureQueue.java
@@ -59,10 +59,11 @@ import org.slf4j.LoggerFactory;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.ReplicatedMap;
 
+import gov.pnnl.proven.cluster.lib.disclosure.exception.JSONDataValidationException;
 import gov.pnnl.proven.cluster.lib.disclosure.exception.UnsupportedDisclosureType;
 import gov.pnnl.proven.cluster.lib.disclosure.exchange.BufferedItemState;
-import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureType;
 import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
+import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureType;
 import gov.pnnl.proven.cluster.lib.disclosure.message.exception.CsvParsingException;
 import gov.pnnl.proven.cluster.lib.module.component.annotation.Scalable;
 import gov.pnnl.proven.cluster.lib.module.component.maintenance.ComponentMaintenance;
@@ -274,14 +275,14 @@ public class DisclosureQueue extends ExchangeComponent {
 						entries = new ItemParser(disclosedItem).parse();
 					}
 					// TODO Add support for large CSV parsing
-					// For now, create DisclosureProxy without parsing
+					// For now, create DisclosureItem without parsing
 					else if (DisclosureType.CSV == itemType) {
-						DisclosureItem csvDp = new DisclosureItem(disclosedItem);
-						entries.add(csvDp);
+						DisclosureItem csvDi = new DisclosureItem(disclosedItem);
+						entries.add(csvDi);
 					} else {
 						throw new UnsupportedDisclosureType("Could not determine entry type for large message");
 					}
-				} catch (UnsupportedDisclosureType | JsonParsingException | CsvParsingException e) {
+				} catch (UnsupportedDisclosureType | JsonParsingException | JSONDataValidationException | CsvParsingException e) {
 					log.error("Failed to process large disclosure entry", e);
 					log.error("Entry discarded");
 					e.printStackTrace();
@@ -442,7 +443,7 @@ public class DisclosureQueue extends ExchangeComponent {
 
 			try {
 				items.add(new DisclosureItem(item));
-			} catch (UnsupportedDisclosureType | JsonParsingException | CsvParsingException e) {
+			} catch ( JsonParsingException | CsvParsingException | JSONDataValidationException | UnsupportedDisclosureType e) {
 				log.error("Failed to process a new disclosure item", e);
 				log.error("Item discarded:");
 				log.error(item);

--- a/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/ItemParser.java
+++ b/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/exchange/ItemParser.java
@@ -60,6 +60,7 @@ import javax.json.stream.JsonParserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import gov.pnnl.proven.cluster.lib.disclosure.exception.JSONDataValidationException;
 import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
 import gov.pnnl.proven.cluster.lib.disclosure.message.MessageUtils;
 import gov.pnnl.proven.cluster.lib.module.exchange.exception.EntryParserException;
@@ -258,13 +259,13 @@ public class ItemParser {
 
 	}
 
-	public List<DisclosureItem> parse() {
+	public List<DisclosureItem> parse() throws JSONDataValidationException {
 
 		log.debug("PARSER STARTED");
 		List<DisclosureItem> ret = parse(null);
-		for (DisclosureItem dp : ret) {
+		for (DisclosureItem di : ret) {
 			log.debug("START CHUNKED MESSAGE################");
-			log.debug(dp.getJsonEntry().toString());
+			log.debug(di.getMessage().toString());
 			log.debug("END CHUNKED MESSAGE  ################");
 		}
 
@@ -272,7 +273,7 @@ public class ItemParser {
 		return ret;
 	}
 
-	private List<DisclosureItem> parse(ItemBuilder eBuilder) {
+	private List<DisclosureItem> parse(ItemBuilder eBuilder) throws JSONDataValidationException {
 
 		List<DisclosureItem> ret = new ArrayList<>();
 		boolean isRoot = false;
@@ -425,7 +426,7 @@ public class ItemParser {
 		return ret;
 	}
 
-	private DisclosureItem buildMessage() {
+	private DisclosureItem buildMessage() throws JSONDataValidationException {
 
 		DisclosureItem ret = null;
 		ItemBuilder temp;

--- a/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/request/module/RequestItem.java
+++ b/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/request/module/RequestItem.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 
 import gov.pnnl.proven.cluster.lib.disclosure.exchange.BufferedItem;
 import gov.pnnl.proven.cluster.lib.disclosure.exchange.BufferedItemState;
+import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
 import gov.pnnl.proven.cluster.lib.module.exchange.RequestBuffer;
 import gov.pnnl.proven.cluster.lib.module.exchange.ServiceBuffer;
 
@@ -60,7 +61,7 @@ import gov.pnnl.proven.cluster.lib.module.exchange.ServiceBuffer;
  * @author d3j766
  *
  */
-public class RequestItem<T> implements BufferedItem, Serializable {
+public class RequestItem<T> extends DisclosureItem implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 

--- a/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/util/ModuleIDSFactory.java
+++ b/proven-member/module-lib/src/main/java/gov/pnnl/proven/cluster/lib/module/util/ModuleIDSFactory.java
@@ -3,8 +3,6 @@ package gov.pnnl.proven.cluster.lib.module.util;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-import gov.pnnl.proven.cluster.lib.disclosure.DisclosureDomain;
-import gov.pnnl.proven.cluster.lib.disclosure.exchange.DisclosureItem;
 import gov.pnnl.proven.cluster.lib.module.messenger.event.StatusOperationEvent;
 import gov.pnnl.proven.cluster.lib.module.registry.ComponentEntry;
 import gov.pnnl.proven.cluster.lib.module.registry.EntryIdentifier;
@@ -32,17 +30,16 @@ public class ModuleIDSFactory implements DataSerializableFactory {
 	public static final int ENTRY_IDENTIFIER_TYPE = 0;
 	public static final int ENTRY_PROPERTY_TYPE = 1;
 	public static final int ENTRY_PROPERTIES_TYPE = 2;
-	public static final int ENTRY_LOCATION_TYPE =3;
+	public static final int ENTRY_LOCATION_TYPE = 3;
 	public static final int COMPONENT_ENTRY_TYPE = 4;
 	public static final int MAINTENENACE_OPERATION_RESULT_ENTRY_TYPE = 5;
 	public static final int MAINTENANCE_RESULT_ENTRY_TYPE = 6;
 	public static final int STATUS_OPERATION_EVENT_TYPE = 7;
-	
 
 	@Override
 	public IdentifiedDataSerializable create(int typeId) {
 
-		switch (typeId) {		
+		switch (typeId) {
 		case (ENTRY_IDENTIFIER_TYPE):
 			return new EntryIdentifier();
 		case (ENTRY_PROPERTY_TYPE):

--- a/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/MessageContentRoutingService.java
+++ b/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/MessageContentRoutingService.java
@@ -508,7 +508,7 @@ public class MessageContentRoutingService {
 
 	}
 
-	private MessageContentRoutingResponse writeKnowledgeMessage(JsonObject val) {
+	private MessageContentRoutingResponse writeKnowledgeMessage(ProvenMessage val) {
 		MessageContentRoutingResponse ret = null;
 		long now = Instant.now().toEpochMilli();
 		String nowStr = ((Long)now).toString();
@@ -523,7 +523,7 @@ public class MessageContentRoutingService {
 		IMap<String, ProvenMessage> provenMessages = client.getMap("gov.pnnl.proven.common.knowledge.message");
 		
 		System.out.println(val.toString());
-		KnowledgeMessage km = new KnowledgeMessage(val, MessageContent.Measurement);
+		KnowledgeMessage km = new KnowledgeMessage(val);
 
 		provenMessages.put(nowStr, (ProvenMessage)km);
 		return new MessageContentRoutingResponse(Response.Status.ACCEPTED,1);
@@ -538,20 +538,20 @@ public class MessageContentRoutingService {
 		try {
 	
 			MessageContentGroup mcg = MessageContentGroup.Knowledge;
-	        System.out.println("!!!!!!!!ADD!!!!!!!!!!!!!!!!!     " + detectObjectType(sourceMessage.getMessage()));
-	        if (detectObjectType(sourceMessage.getMessage()).equalsIgnoreCase("I")) {
-	        	JsonObject x = simulationInput2ProvenMeasurement (sourceMessage.getMessage()); 
-	        	loadResponse = writeKnowledgeMessage(x);
-	        } else if (detectObjectType(sourceMessage.getMessage()).equalsIgnoreCase("O")) {
-	        	JsonObject x = simulationOutput2ProvenMeasurement (sourceMessage.getMessage()); 
-	        	loadResponse = writeKnowledgeMessage(x);
+	        System.out.println("!!!!!!!!ADD!!!!!!!!!!!!!!!!!     " + detectObjectType(sourceMessage.getDisclosureItem().getMessage()));
+	        if (detectObjectType(sourceMessage.getDisclosureItem().getMessage()).equalsIgnoreCase("I")) {
+	        	JsonObject x = simulationInput2ProvenMeasurement (sourceMessage.getDisclosureItem().getMessage()); 
+	        	loadResponse = writeKnowledgeMessage(sourceMessage);
+	        } else if (detectObjectType(sourceMessage.getDisclosureItem().getMessage()).equalsIgnoreCase("O")) {
+	        	JsonObject x = simulationOutput2ProvenMeasurement (sourceMessage.getDisclosureItem().getMessage()); 
+	        	loadResponse = writeKnowledgeMessage(sourceMessage);
 	        }
 
 			JsonReader reader = Json.createReader(new StringReader(jsonb.toJson(loadResponse)));
 			JsonObject loadResponseObject = reader.readObject();
 			//JsonReader reader = Json.createReader(new StringReader(""));
-			ret = new ResponseMessage(Response.Status.fromStatusCode(loadResponse.statusCode), sourceMessage,
-					loadResponseObject);
+			ret = new ResponseMessage(Response.Status.fromStatusCode(loadResponse.statusCode), loadResponseObject,
+					sourceMessage);
 
 		} catch (Exception ex) {
 
@@ -583,8 +583,8 @@ public class MessageContentRoutingService {
 	private ResponseMessage createResponseMessage(MessageContentRoutingResponse mcrResponse, ProvenMessage sourceMessage) {
 	JsonReader reader = Json.createReader(new StringReader(jsonb.toJson(mcrResponse)));
 	JsonObject loadResponseObject = reader.readObject();
-	return new ResponseMessage(Response.Status.fromStatusCode(mcrResponse.statusCode), sourceMessage,
-			loadResponseObject);
+	return new ResponseMessage(Response.Status.fromStatusCode(mcrResponse.statusCode), loadResponseObject,
+			sourceMessage);
 }	
 	
 	

--- a/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/T3Service.java
+++ b/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/T3Service.java
@@ -155,20 +155,20 @@ public class T3Service {
 		try {
 	
 			// Construct initial data model
-			String message = MessageUtils.prependContext(sourceMessage.getDomain(),
-					sourceMessage.getMessage().toString());
+			String message = MessageUtils.prependContext(sourceMessage.getDisclosureItem().getDisclosureDomain(),
+					sourceMessage.getDisclosureItem().getMessage().toString());
 			Model dataModel = MessageUtils.createMessageDataModel(sourceMessage, message);
 
 			// SHACL rule processing to produce final message data model
-			dataModel = MessageUtils.addShaclRuleResults(sourceMessage.getDomain(), dataModel);
+			dataModel = MessageUtils.addShaclRuleResults(sourceMessage.getDisclosureItem().getDisclosureDomain(), dataModel);
 
 			// Load message into T3 store and return response
 			loadResponse = loadMessageData(dataModel, sourceMessage);
 			JsonReader reader = Json.createReader(new StringReader(jsonb.toJson(loadResponse)));
 			//JsonReader reader = Json.createReader(new StringReader(""));
 			JsonObject loadResponseObject = reader.readObject();
-			ret = new ResponseMessage(Response.Status.fromStatusCode(loadResponse.statusCode), sourceMessage,
-					loadResponseObject);
+			ret = new ResponseMessage(Response.Status.fromStatusCode(loadResponse.statusCode), loadResponseObject,
+					sourceMessage);
 
 		} catch (Exception ex) {
 
@@ -193,8 +193,8 @@ public class T3Service {
 		JsonReader reader = Json.createReader(new StringReader(jsonb.toJson(t3Response)));
 		//JsonReader reader = Json.createReader(new StringReader(""));
 		JsonObject loadResponseObject = reader.readObject();
-		return new ResponseMessage(Response.Status.fromStatusCode(t3Response.statusCode), sourceMessage,
-				loadResponseObject);
+		return new ResponseMessage(Response.Status.fromStatusCode(t3Response.statusCode), loadResponseObject,
+				sourceMessage);
 	}
 
 	/*
@@ -224,7 +224,7 @@ public class T3Service {
 				}
 			}).start();
 			ValueFactoryImpl vf = ValueFactoryImpl.getInstance();
-			URI context = vf.createURI("http://" + sourceMessage.getDomain().getDomain());
+			URI context = vf.createURI("http://" + sourceMessage.getDisclosureItem().getDisclosureDomain().getDomain());
 			RemoteRepository.AddOp operation = new RemoteRepository.AddOp(pis, addFormat);
 			operation.setContext(context);
 			long t3Count = repo.add(operation);

--- a/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/TsService.java
+++ b/proven-member/pipeline-lib/src/main/java/gov/pnnl/cluster/lib/pipeline/TsService.java
@@ -179,11 +179,11 @@ public class TsService {
         ldbuilder.add("id", "id");
         ldbuilder.add("date", "2020");
 		JsonObject loadResponseObject = ldbuilder.build();
-		ret = new ResponseMessage(Response.Status.CREATED, sourceMessage,
-				loadResponseObject);
+		ret = new ResponseMessage(Response.Status.CREATED, loadResponseObject,
+				sourceMessage);
 	
 			// Construct initial data model
-			JsonObject mObject = sourceMessage.getMessage();
+			JsonObject mObject = sourceMessage.getDisclosureItem().getMessage();
 
 			
 			if (useIdb) {
@@ -250,8 +250,8 @@ public class TsService {
 				JsonReader  reader = Json.createReader(new StringReader(jsonb.toJson("{}")));
 				loadResponseObject = reader.readObject();
 				//JsonReader reader = Json.createReader(new StringReader(""));
-				ret = new ResponseMessage(Response.Status.CREATED, sourceMessage,
-						loadResponseObject);
+				ret = new ResponseMessage(Response.Status.CREATED, loadResponseObject,
+						sourceMessage);
 				int i = 0;
 				i = i + 1;
 				return ret;
@@ -309,8 +309,8 @@ public class TsService {
 		JsonReader reader = Json.createReader(new StringReader(jsonb.toJson(tsResponse)));
 		//JsonReader reader = Json.createReader(new StringReader(""));
 		JsonObject loadResponseObject = reader.readObject();
-		return new ResponseMessage(Response.Status.fromStatusCode(tsResponse.statusCode), sourceMessage,
-				loadResponseObject);
+		return new ResponseMessage(Response.Status.fromStatusCode(tsResponse.statusCode), loadResponseObject,
+				sourceMessage);
 	}
 
 	/*


### PR DESCRIPTION
Fixes #64

+ Modified DiscosureItem to perform message schema validation.  Plan to
support external disclosure of DisclosureItem object directly, pushing
schema validation to client applications.
+ Removed schema validation from DisclosureMessage construction.
+ Modified ProvenMessage constructors to support recording of message
lineage.  DisclosureItem is now a property of ProvenMessage,
representing the disclosed proven-message properties.  
+ Created DisclosureProperty to document proven-message properties.
+ Minor modifications to existing pipelines to support changes to
ProvenMessage.
+ Modified proven message schema; provided additional documentation,
patterns, and removal of mimeType property. 
+ Modified Server-Side Event (SSE) implementation in disclosure-module
to support changes made to ProvenMessage.